### PR TITLE
feat: add Shift+Enter to run notebook cell

### DIFF
--- a/support_console/static/app.js
+++ b/support_console/static/app.js
@@ -757,7 +757,7 @@
 
     var runBtn = document.createElement('button');
     runBtn.className = 'cell-btn cell-btn-run';
-    runBtn.title = 'Run cell (Ctrl+Enter)';
+    runBtn.title = 'Run cell (Shift+Enter)';
     runBtn.dataset.action = 'run';
     runBtn.textContent = '\u25B6'; // play triangle
     actions.appendChild(runBtn);
@@ -1058,8 +1058,8 @@
       textarea.dispatchEvent(new Event('input'));
     }
 
-    // Ctrl/Cmd + Enter to run cell
-    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    // Ctrl/Cmd + Enter or Shift + Enter to run cell
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey || e.shiftKey)) {
       e.preventDefault();
       var cellEl = textarea.closest('.cell');
       if (cellEl) {


### PR DESCRIPTION
## Summary
- Add `Shift+Enter` as a keyboard shortcut to run notebook cells, matching the standard Jupyter Notebook convention
- `Ctrl/Cmd+Enter` continues to work as before
- Update run button tooltip to reflect the more common `Shift+Enter` shortcut

## Test plan
- [ ] Open the notebook panel and type code in a cell
- [ ] Press `Shift+Enter` — cell should execute
- [ ] Press `Ctrl+Enter` / `Cmd+Enter` — cell should still execute
- [ ] Press plain `Enter` — should insert a newline as usual
- [ ] Hover the run button — tooltip should say "Run cell (Shift+Enter)"