### PR TITLE
feat: add Jedi-powered autocomplete for notebook cells

### DIFF
--- a/support_console/kernel.py
+++ b/support_console/kernel.py
@@ -241,6 +241,67 @@ class KernelSession:
             logger.warning("Failed to interrupt kernel %s", self._session_id, exc_info=True)
             return False
 
+    async def complete(self, code: str, cursor_pos: int, timeout: float = 3.0) -> dict:
+        """Request code completions from the kernel.
+
+        Args:
+            code: The code context to complete in.
+            cursor_pos: Cursor position (character offset) in *code*.
+            timeout: Maximum seconds to wait for a reply.
+
+        Returns:
+            Dictionary with keys: matches, cursor_start, cursor_end, metadata, status.
+
+        Raises:
+            KernelNotStartedError: If the kernel is not running.
+        """
+        self._ensure_started()
+
+        empty = {
+            "matches": [],
+            "cursor_start": cursor_pos,
+            "cursor_end": cursor_pos,
+            "metadata": {},
+            "status": "ok",
+        }
+
+        # Guard: ZMQ sockets are not thread-safe. If an execution is in
+        # progress we must not touch the shell channel concurrently.
+        if self._busy:
+            return empty
+
+        try:
+            kc = self._kc
+            msg_id = await asyncio.to_thread(kc.complete, code, cursor_pos)
+
+            # Drain shell channel until we find the matching complete_reply.
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return empty
+                poll_timeout = min(remaining, 0.5)
+                try:
+                    reply = await asyncio.to_thread(
+                        kc.get_shell_msg, timeout=poll_timeout
+                    )
+                except Exception:
+                    continue
+                if reply.get("parent_header", {}).get("msg_id") == msg_id:
+                    break
+
+            content = reply.get("content", {})
+            return {
+                "matches": content.get("matches", []),
+                "cursor_start": content.get("cursor_start", cursor_pos),
+                "cursor_end": content.get("cursor_end", cursor_pos),
+                "metadata": content.get("metadata", {}),
+                "status": content.get("status", "ok"),
+            }
+        except Exception:
+            logger.debug("Completion failed in kernel %s", self._session_id, exc_info=True)
+            return empty
+
     # ------------------------------------------------------------------
     # Status
     # ------------------------------------------------------------------

--- a/support_console/server.py
+++ b/support_console/server.py
@@ -18,7 +18,7 @@ from typing import Optional
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # WebSocket safety limits
 WS_MAX_MESSAGE_SIZE = 1024 * 1024  # 1 MB max per message
@@ -47,6 +47,11 @@ class ExecuteRequest(BaseModel):
     def clamped_timeout(self) -> float:
         """Return timeout clamped to a safe range (1-300 seconds)."""
         return max(1.0, min(self.timeout, 300.0))
+
+
+class CompleteRequest(BaseModel):
+    code: str
+    cursor_pos: int = Field(ge=0)
 
 
 class SessionCreateRequest(BaseModel):
@@ -269,6 +274,31 @@ def create_app(
             raise HTTPException(status_code=408, detail="Execution timed out")
         except KernelError as exc:
             raise HTTPException(status_code=500, detail=str(exc))
+
+    @app.post("/api/kernel/complete")
+    async def kernel_complete(req: CompleteRequest):
+        """Request code completions from the IPython kernel."""
+        kernel = app.state.console.kernel
+        if kernel is None or not kernel.is_alive:
+            return {
+                "matches": [],
+                "cursor_start": req.cursor_pos,
+                "cursor_end": req.cursor_pos,
+                "metadata": {},
+                "status": "ok",
+            }
+
+        try:
+            result = await kernel.complete(req.code, req.cursor_pos)
+            return result
+        except Exception:
+            return {
+                "matches": [],
+                "cursor_start": req.cursor_pos,
+                "cursor_end": req.cursor_pos,
+                "metadata": {},
+                "status": "ok",
+            }
 
     @app.post("/api/kernel/interrupt")
     async def kernel_interrupt():

--- a/support_console/static/app.js
+++ b/support_console/static/app.js
@@ -21,6 +21,8 @@
     kernelPollInterval: 10000,
     chatAutoScrollThreshold: 80,
     maxInputHeight: 160,
+    autocompleteDebounceMs: 150,
+    autocompleteMaxItems: 20,
   };
 
   // --------------------------------------------------------
@@ -51,6 +53,19 @@
 
     // Divider drag
     isDragging: false,
+
+    // Autocomplete
+    autocomplete: {
+      visible: false,
+      matches: [],
+      selectedIndex: 0,
+      cursorStart: 0,
+      cursorEnd: 0,
+      textarea: null,
+      debounceTimer: null,
+      requestId: 0,
+      isInserting: false,
+    },
   };
 
   // --------------------------------------------------------
@@ -75,6 +90,13 @@
     dom.clearNotebook = document.getElementById('clear-notebook');
     dom.reconnectingOverlay = document.getElementById('reconnecting-overlay');
     dom.main = document.getElementById('main');
+
+    // Create shared autocomplete dropdown
+    dom.autocompleteDropdown = document.createElement('div');
+    dom.autocompleteDropdown.className = 'autocomplete-dropdown';
+    dom.autocompleteDropdown.id = 'autocomplete-dropdown';
+    dom.autocompleteDropdown.setAttribute('role', 'listbox');
+    document.body.appendChild(dom.autocompleteDropdown);
   }
 
   // --------------------------------------------------------
@@ -799,6 +821,7 @@
     // Wire up textarea events
     textarea.addEventListener('keydown', handleCellTextareaKeydown);
     textarea.addEventListener('input', autosizeCellTextarea);
+    textarea.addEventListener('input', handleCellTextareaInput);
 
     // Initial autosize
     requestAnimationFrame(function () {
@@ -1024,7 +1047,31 @@
   function handleCellTextareaKeydown(e) {
     var textarea = e.target;
 
-    // Tab key inserts spaces instead of moving focus
+    // --- Autocomplete keyboard navigation (when dropdown is visible) ---
+    if (state.autocomplete.visible) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        autocompleteNavigate(1);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        autocompleteNavigate(-1);
+        return;
+      }
+      if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
+        e.preventDefault();
+        autocompleteAccept();
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        autocompleteDismiss();
+        return;
+      }
+    }
+
+    // Tab key — autocomplete or indent
     if (e.key === 'Tab') {
       e.preventDefault();
       var start = textarea.selectionStart;
@@ -1049,7 +1096,14 @@
           textarea.selectionStart = textarea.selectionEnd = start - removed;
         }
       } else {
-        // Insert 4 spaces (soft tab)
+        // Check if there's a partial identifier before cursor → trigger autocomplete
+        var word = getWordBeforeCursor(textarea);
+        if (word.length > 0) {
+          triggerAutocomplete(textarea);
+          return;
+        }
+
+        // Otherwise insert 4 spaces (soft tab)
         textarea.value = textarea.value.substring(0, start) + '    ' + textarea.value.substring(end);
         textarea.selectionStart = textarea.selectionEnd = start + 4;
       }
@@ -1072,6 +1126,285 @@
     var textarea = this;
     textarea.style.height = 'auto';
     textarea.style.height = Math.max(60, textarea.scrollHeight) + 'px';
+  }
+
+  // --------------------------------------------------------
+  // Autocomplete
+  // --------------------------------------------------------
+
+  function getWordBeforeCursor(textarea) {
+    var val = textarea.value;
+    var pos = textarea.selectionStart;
+    var i = pos - 1;
+    while (i >= 0 && /[a-zA-Z0-9_.]/.test(val[i])) {
+      i--;
+    }
+    return val.substring(i + 1, pos);
+  }
+
+  function handleCellTextareaInput(e) {
+    var textarea = e.target;
+
+    // Guard: skip when autocompleteAccept is modifying the textarea value
+    if (state.autocomplete.isInserting) return;
+
+    var pos = textarea.selectionStart;
+    var charBefore = pos > 0 ? textarea.value[pos - 1] : '';
+
+    // Dot after an identifier char → trigger autocomplete (debounced)
+    if (charBefore === '.' && pos > 1 && /[a-zA-Z0-9_)]/.test(textarea.value[pos - 2])) {
+      debouncedAutocomplete(textarea);
+      return;
+    }
+
+    // If dropdown visible and user keeps typing identifier chars → re-trigger
+    if (state.autocomplete.visible && /[a-zA-Z0-9_]/.test(charBefore)) {
+      debouncedAutocomplete(textarea);
+      return;
+    }
+
+    // If dropdown visible and user types a non-identifier char → dismiss
+    if (state.autocomplete.visible) {
+      autocompleteDismiss();
+    }
+  }
+
+  function debouncedAutocomplete(textarea) {
+    if (state.autocomplete.debounceTimer) {
+      clearTimeout(state.autocomplete.debounceTimer);
+    }
+    state.autocomplete.debounceTimer = setTimeout(function () {
+      state.autocomplete.debounceTimer = null;
+      triggerAutocomplete(textarea);
+    }, CONFIG.autocompleteDebounceMs);
+  }
+
+  function triggerAutocomplete(textarea) {
+    var code = textarea.value;
+    var cursorPos = textarea.selectionStart;
+
+    state.autocomplete.requestId++;
+    var myRequestId = state.autocomplete.requestId;
+
+    fetch('/api/kernel/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: code, cursor_pos: cursorPos }),
+    })
+      .then(function (resp) { return resp.json(); })
+      .then(function (data) {
+        // Discard stale responses
+        if (myRequestId !== state.autocomplete.requestId) return;
+
+        var matches = (data.matches || []).slice(0, CONFIG.autocompleteMaxItems);
+        if (matches.length === 0) {
+          autocompleteDismiss();
+          return;
+        }
+
+        state.autocomplete.matches = matches;
+        state.autocomplete.cursorStart = data.cursor_start;
+        state.autocomplete.cursorEnd = data.cursor_end;
+        state.autocomplete.textarea = textarea;
+        state.autocomplete.selectedIndex = 0;
+
+        showAutocompleteDropdown(textarea, matches);
+      })
+      .catch(function () {
+        autocompleteDismiss();
+      });
+  }
+
+  function getCaretCoordinates(textarea, position) {
+    var div = document.createElement('div');
+    var style = window.getComputedStyle(textarea);
+    var properties = [
+      'fontFamily', 'fontSize', 'fontWeight', 'fontStyle',
+      'letterSpacing', 'textTransform', 'wordSpacing', 'textIndent',
+      'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft',
+      'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth',
+      'lineHeight', 'tabSize',
+    ];
+
+    div.style.position = 'absolute';
+    div.style.top = '-9999px';
+    div.style.left = '-9999px';
+    div.style.whiteSpace = 'pre-wrap';
+    div.style.wordWrap = 'break-word';
+    div.style.overflow = 'hidden';
+    div.style.width = style.width;
+
+    for (var i = 0; i < properties.length; i++) {
+      div.style[properties[i]] = style[properties[i]];
+    }
+
+    var textBefore = textarea.value.substring(0, position);
+    var textNode = document.createTextNode(textBefore);
+    div.appendChild(textNode);
+
+    var marker = document.createElement('span');
+    marker.textContent = '|';
+    div.appendChild(marker);
+
+    document.body.appendChild(div);
+
+    var markerRect = marker.offsetTop;
+    var markerLeft = marker.offsetLeft;
+    var markerHeight = marker.offsetHeight;
+
+    // Account for textarea scroll
+    var top = markerRect - textarea.scrollTop;
+    var left = markerLeft - textarea.scrollLeft;
+
+    document.body.removeChild(div);
+
+    return { top: top, left: left, height: markerHeight };
+  }
+
+  function showAutocompleteDropdown(textarea, matches) {
+    var dropdown = dom.autocompleteDropdown;
+
+    // Clear previous items
+    while (dropdown.firstChild) {
+      dropdown.removeChild(dropdown.firstChild);
+    }
+
+    for (var i = 0; i < matches.length; i++) {
+      var item = document.createElement('div');
+      var itemId = 'autocomplete-item-' + i;
+      item.className = 'autocomplete-item' + (i === 0 ? ' selected' : '');
+      item.id = itemId;
+      item.textContent = matches[i];
+      item.dataset.index = i;
+      item.setAttribute('role', 'option');
+      if (i === 0) item.setAttribute('aria-selected', 'true');
+      item.addEventListener('mousedown', onAutocompleteItemMousedown);
+      dropdown.appendChild(item);
+    }
+
+    // Set ARIA attributes on the textarea
+    textarea.setAttribute('aria-haspopup', 'listbox');
+    textarea.setAttribute('aria-expanded', 'true');
+    textarea.setAttribute('aria-controls', 'autocomplete-dropdown');
+    textarea.setAttribute('aria-activedescendant', 'autocomplete-item-0');
+
+    // Position the dropdown below the cursor
+    var caretCoords = getCaretCoordinates(textarea, textarea.selectionStart);
+    var textareaRect = textarea.getBoundingClientRect();
+
+    var top = textareaRect.top + caretCoords.top + caretCoords.height + 2;
+    var left = textareaRect.left + caretCoords.left;
+
+    dropdown.style.top = top + 'px';
+    dropdown.style.left = left + 'px';
+    dropdown.classList.add('visible');
+
+    // Flip above if overflows bottom
+    var dropdownRect = dropdown.getBoundingClientRect();
+    if (dropdownRect.bottom > window.innerHeight) {
+      var flippedTop = textareaRect.top + caretCoords.top - dropdownRect.height - 2;
+      if (flippedTop >= 0) {
+        dropdown.style.top = flippedTop + 'px';
+      }
+    }
+
+    // Clamp to right edge
+    dropdownRect = dropdown.getBoundingClientRect();
+    if (dropdownRect.right > window.innerWidth) {
+      dropdown.style.left = Math.max(0, window.innerWidth - dropdownRect.width - 4) + 'px';
+    }
+
+    state.autocomplete.visible = true;
+  }
+
+  function onAutocompleteItemMousedown(e) {
+    e.preventDefault();
+    var index = parseInt(e.currentTarget.dataset.index, 10);
+    state.autocomplete.selectedIndex = index;
+    autocompleteAccept();
+  }
+
+  function autocompleteNavigate(delta) {
+    var ac = state.autocomplete;
+    var count = ac.matches.length;
+    if (count === 0) return;
+
+    ac.selectedIndex = (ac.selectedIndex + delta + count) % count;
+
+    var items = dom.autocompleteDropdown.querySelectorAll('.autocomplete-item');
+    for (var i = 0; i < items.length; i++) {
+      if (i === ac.selectedIndex) {
+        items[i].classList.add('selected');
+        items[i].setAttribute('aria-selected', 'true');
+        // Scroll into view
+        items[i].scrollIntoView({ block: 'nearest' });
+      } else {
+        items[i].classList.remove('selected');
+        items[i].removeAttribute('aria-selected');
+      }
+    }
+
+    // Update aria-activedescendant on the textarea
+    if (ac.textarea) {
+      ac.textarea.setAttribute('aria-activedescendant', 'autocomplete-item-' + ac.selectedIndex);
+    }
+  }
+
+  function autocompleteAccept() {
+    var ac = state.autocomplete;
+    if (!ac.visible || ac.matches.length === 0) return;
+
+    var textarea = ac.textarea;
+    var match = ac.matches[ac.selectedIndex];
+    var val = textarea.value;
+
+    ac.isInserting = true;
+
+    textarea.value = val.substring(0, ac.cursorStart) + match + val.substring(ac.cursorEnd);
+    var newPos = ac.cursorStart + match.length;
+    textarea.selectionStart = textarea.selectionEnd = newPos;
+
+    // Trigger input event for autosize
+    textarea.dispatchEvent(new Event('input'));
+
+    ac.isInserting = false;
+
+    autocompleteDismiss();
+    textarea.focus();
+  }
+
+  function autocompleteDismiss() {
+    // Clear ARIA attributes from the textarea
+    if (state.autocomplete.textarea) {
+      state.autocomplete.textarea.setAttribute('aria-expanded', 'false');
+      state.autocomplete.textarea.removeAttribute('aria-activedescendant');
+    }
+
+    state.autocomplete.visible = false;
+    state.autocomplete.matches = [];
+    state.autocomplete.selectedIndex = 0;
+    state.autocomplete.textarea = null;
+    dom.autocompleteDropdown.classList.remove('visible');
+
+    if (state.autocomplete.debounceTimer) {
+      clearTimeout(state.autocomplete.debounceTimer);
+      state.autocomplete.debounceTimer = null;
+    }
+  }
+
+  function setupAutocompleteDismiss() {
+    document.addEventListener('mousedown', function (e) {
+      if (!state.autocomplete.visible) return;
+      if (dom.autocompleteDropdown.contains(e.target)) return;
+      if (state.autocomplete.textarea && state.autocomplete.textarea === e.target) return;
+      autocompleteDismiss();
+    });
+
+    dom.notebookCells.addEventListener('scroll', function () {
+      if (state.autocomplete.visible) {
+        autocompleteDismiss();
+      }
+    });
   }
 
   // --------------------------------------------------------
@@ -1257,6 +1590,7 @@
     setupChatInput();
     setupNotebookControls();
     setupDivider();
+    setupAutocompleteDismiss();
     connectWebSocket();
     startKernelPolling();
   }

--- a/support_console/static/style.css
+++ b/support_console/static/style.css
@@ -1075,6 +1075,46 @@ html, body {
 
 /* --- Responsive tweaks for very small screens --- */
 
+/* --- Autocomplete Dropdown --- */
+
+.autocomplete-dropdown {
+  position: fixed;
+  z-index: 500;
+  min-width: 200px;
+  max-width: 400px;
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  display: none;
+}
+
+.autocomplete-dropdown.visible {
+  display: block;
+}
+
+.autocomplete-item {
+  padding: 4px 10px;
+  cursor: pointer;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.autocomplete-item:hover {
+  background: var(--bg-hover);
+}
+
+.autocomplete-item.selected {
+  background: var(--accent-blue);
+  color: #fff;
+}
+
 @media (max-width: 700px) {
   #main {
     flex-direction: column;

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -187,3 +187,42 @@ async def test_stderr_capture(kernel):
     """Stderr output is captured separately."""
     result = await kernel.execute('import sys; print("error msg", file=sys.stderr)')
     assert "error msg" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_complete_basic(kernel):
+    """Complete returns matches from Jedi via the kernel."""
+    await kernel.execute("import os")
+    result = await kernel.complete("os.pa", cursor_pos=5)
+    assert result["status"] == "ok"
+    assert "path" in result["matches"]
+
+
+@pytest.mark.asyncio
+async def test_complete_empty(kernel):
+    """Complete with nonsense returns empty matches."""
+    result = await kernel.complete("xyzzynonexistent.qqq", cursor_pos=20)
+    assert result["status"] == "ok"
+    assert result["matches"] == []
+
+
+@pytest.mark.asyncio
+async def test_complete_before_start():
+    """Complete raises KernelNotStartedError if kernel not started."""
+    k = KernelSession()
+    with pytest.raises(KernelNotStartedError):
+        await k.complete("os.pa", cursor_pos=5)
+
+
+@pytest.mark.asyncio
+async def test_complete_when_busy(kernel):
+    """Complete returns empty matches when kernel is busy executing."""
+    kernel._busy = True
+    try:
+        result = await kernel.complete("os.pa", cursor_pos=5)
+        assert result["status"] == "ok"
+        assert result["matches"] == []
+        assert result["cursor_start"] == 5
+        assert result["cursor_end"] == 5
+    finally:
+        kernel._busy = False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -108,6 +108,35 @@ class TestKernelEndpoints:
         data = resp.json()
         assert "output" in data
 
+    async def test_kernel_complete(self, app_with_client):
+        app, client = app_with_client
+        kernel = app.state.console.kernel
+        kernel.complete = AsyncMock(return_value={
+            "matches": ["path", "pathsep"],
+            "cursor_start": 3,
+            "cursor_end": 5,
+            "metadata": {},
+            "status": "ok",
+        })
+        resp = await client.post("/api/kernel/complete", json={"code": "os.pa", "cursor_pos": 5})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "path" in data["matches"]
+        assert data["status"] == "ok"
+        kernel.complete.assert_called_once_with("os.pa", 5)
+
+    async def test_kernel_complete_when_dead(self, app_with_client):
+        app, client = app_with_client
+        kernel = app.state.console.kernel
+        kernel.is_alive = False
+        resp = await client.post("/api/kernel/complete", json={"code": "os.pa", "cursor_pos": 5})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["matches"] == []
+        assert data["cursor_start"] == 5
+        assert data["cursor_end"] == 5
+        assert data["status"] == "ok"
+
 
 class TestSessionEndpoints:
     """Tests for session API endpoints."""


### PR DESCRIPTION
## Summary

- Wires IPython kernel's `complete_request`/`complete_reply` to the frontend, giving notebook cells Tab-completion similar to Jupyter Notebook
- `KernelSession.complete()` with `_busy` guard for ZMQ thread safety, `msg_id` matching, and deadline-based timeout
- `POST /api/kernel/complete` endpoint with graceful degradation (empty matches on dead kernel or errors, never 503)
- Frontend autocomplete UI: Tab/dot triggers, debounced fetch, keyboard navigation (Arrow/Enter/Tab/Escape), `requestId` stale-response handling, mirror-div cursor positioning, viewport flip/clamp
- Full ARIA support (`role="listbox"`, `aria-activedescendant`, `aria-expanded`)
- `cursor_pos >= 0` validation, server-side error handling for unexpected exceptions

## Test plan

- [x] All 91 tests pass (`pytest tests/ -v`)
- [x] New kernel tests: basic completion, empty matches, before-start error, busy-guard path
- [x] New server tests: endpoint passthrough with `assert_called_once_with`, dead kernel fallback with cursor position assertions
- [ ] Manual: start console, run `import os`, type `os.` in new cell — dropdown appears
- [ ] Manual: type `os.pa` + Tab — filtered completions shown
- [ ] Manual: Arrow keys navigate, Enter/Tab accepts, Escape dismisses
- [ ] Manual: Tab on empty line still inserts 4 spaces, Shift+Tab still dedents